### PR TITLE
Fix mono playback

### DIFF
--- a/toccata_playback.sv
+++ b/toccata_playback.sv
@@ -213,18 +213,23 @@ always_ff @(posedge clk) begin
                 rd_en <= 1'b1;
                 if (rd_en == 1'b1) begin
                     pb_state <= pb_state.next();
+                    rd_en <= 1'b0;
                 end
             end
             STEP_1_MONO: begin
                 if (fmt == 1'b0 || lc == 1'b1) begin // 8-bit
                     // Make 8-bit unsigned to 8 bits signed
                     tmp_8bit_left <= data_in - 8'sh80;
+                    pb_state <= pb_state.next();
                 end else begin // 16 bit
                     // Store the LSB first
                     tmp_8bit_left <= data_in;
                     rd_en <= 1'b1; // Get the MSB
+                    if (rd_en == 1'b1) begin
+                        pb_state <= pb_state.next();
+                        rd_en <= 1'b0;
+                    end
                 end
-                pb_state <= pb_state.next();
             end
             STEP_2_MONO: begin
                 if (fmt == 1'b0 || lc == 1'b1) begin // 8-bit


### PR DESCRIPTION
Hi ranzbak,

thanks for this implementation of the Toccata sound card.

It's integrated in the [MinimigAGA-MiST-TC64](https://github.com/minimig-dev/MinimigAGA-MiST-TC64/tree/toccata) project and discussed [here](https://www.atari-forum.com/viewtopic.php?p=458089#p458089).

Mono playback currently is broken so here's a fix.